### PR TITLE
Completely renamed *Session* to *Authorization* in order to improve s…

### DIFF
--- a/Source/Otc.SessionContext.Abstractions/IAuthorizationContext.cs
+++ b/Source/Otc.SessionContext.Abstractions/IAuthorizationContext.cs
@@ -1,0 +1,11 @@
+﻿namespace Otc.AuthorizationContext.Abstractions
+{
+    /// <summary>
+    /// Provide a way to get the authorization data.
+    /// </summary>
+    /// <typeparam name="TAuthorizationData">Type of authorization data model.</typeparam>
+    public interface IAuthorizationContext<TAuthorizationData> where TAuthorizationData : IAuthorizationData
+    {
+        TAuthorizationData AuthorizationData { get; }
+    }
+}

--- a/Source/Otc.SessionContext.Abstractions/IAuthorizationData.cs
+++ b/Source/Otc.SessionContext.Abstractions/IAuthorizationData.cs
@@ -1,0 +1,10 @@
+﻿namespace Otc.AuthorizationContext.Abstractions
+{
+    /// <summary>
+    /// Base interface for authorization data model class.
+    /// </summary>
+    public interface IAuthorizationData
+    {
+        string UserId { get; }
+    }
+}

--- a/Source/Otc.SessionContext.Abstractions/IAuthorizationDataSerializer.cs
+++ b/Source/Otc.SessionContext.Abstractions/IAuthorizationDataSerializer.cs
@@ -1,0 +1,16 @@
+﻿namespace Otc.AuthorizationContext.Abstractions
+{
+    /// <summary>
+    /// Provide the authorization data serializer (token generation).
+    /// </summary>
+    /// <typeparam name="TAuthorizationData">Type of authorization data model.</typeparam>
+    public interface IAuthorizationDataSerializer<TAuthorizationData> where TAuthorizationData : IAuthorizationData
+    {
+        /// <summary>
+        /// Serialize / Generate token.
+        /// </summary>
+        /// <param name="authorizationData">Data to serialize.</param>
+        /// <returns>String with generated token.</returns>
+        string Serialize(TAuthorizationData authorizationData);
+    }
+}

--- a/Source/Otc.SessionContext.Abstractions/ISessionContext.cs
+++ b/Source/Otc.SessionContext.Abstractions/ISessionContext.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace Otc.SessionContext.Abstractions
 {
+    [Obsolete("Otc.SessionContext.Abstractions.ISessionContext now is Otc.AuthorizationContext.Abstractions.IAuthorizationContext. We strongly encourage you to migrate from Otc.SessionContext.Abstractions to Otc.AuthorizationContext.Abstractions.")]
     public interface ISessionContext<TSessionData> where TSessionData : ISessionData
     {
         TSessionData SessionData { get; }

--- a/Source/Otc.SessionContext.Abstractions/ISessionData.cs
+++ b/Source/Otc.SessionContext.Abstractions/ISessionData.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace Otc.SessionContext.Abstractions
 {
+    [Obsolete("Otc.SessionContext.Abstractions.ISessionData now is Otc.AuthorizationContext.Abstractions.IAuthorizationData. We strongly encourage you to migrate from Otc.SessionContext.Abstractions to Otc.AuthorizationContext.Abstractions.")]
     public interface ISessionData
     {
         string UserId { get; }

--- a/Source/Otc.SessionContext.Abstractions/ISessionSerializer.cs
+++ b/Source/Otc.SessionContext.Abstractions/ISessionSerializer.cs
@@ -1,5 +1,8 @@
-﻿namespace Otc.SessionContext.Abstractions
+﻿using System;
+
+namespace Otc.SessionContext.Abstractions
 {
+    [Obsolete("Otc.SessionContext.Abstractions.ISessionSerializer now is Otc.AuthorizationContext.Abstractions.IAuthorizationDataSerializer. We strongly encourage you to migrate from Otc.SessionContext.Abstractions to Otc.AuthorizationContext.Abstractions.")]
     public interface ISessionSerializer<TSessionData> where TSessionData : ISessionData
     {
         string Serialize(TSessionData sessionData);

--- a/Source/Otc.SessionContext.Abstractions/Otc.SessionContext.Abstractions.csproj
+++ b/Source/Otc.SessionContext.Abstractions/Otc.SessionContext.Abstractions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Ole Consignado</Authors>
     <Copyright>Ole Consignado (c) 2018</Copyright>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-session-context</PackageProjectUrl>
   </PropertyGroup>
 

--- a/Source/Otc.SessionContext.AspNetCore.Jwt/AuthorizationContext.cs
+++ b/Source/Otc.SessionContext.AspNetCore.Jwt/AuthorizationContext.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using Otc.AuthorizationContext.Abstractions;
+using System;
+using System.Linq;
+using System.Security.Claims;
+
+namespace Otc.AuthorizationContext.AspNetCore.Jwt
+{
+    public class AuthorizationContext<TAuthorizationData> : IAuthorizationContext<TAuthorizationData>
+        where TAuthorizationData : IAuthorizationData
+    {
+        private readonly IHttpContextAccessor httpContextAccessor;
+
+        public AuthorizationContext(IHttpContextAccessor httpContextAccessor)
+        {
+            this.httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+        }
+
+        private TAuthorizationData authorizationData;
+
+        public TAuthorizationData AuthorizationData
+        {
+            get
+            {
+                if (authorizationData == null)
+                {
+                    var claimsIdentity = httpContextAccessor.HttpContext?.User?.Identity as ClaimsIdentity;
+
+                    if (claimsIdentity == null)
+                    {
+                        throw new UnauthorizedAccessException();
+                    }
+
+                    var authorizationData = claimsIdentity.Claims.Single(c => c.Type == JwtConfiguration.AuthorizationDataJwtTypeName).Value;
+                    this.authorizationData = JsonConvert.DeserializeObject<TAuthorizationData>(authorizationData);
+                }
+
+                return authorizationData;
+            }
+        }
+    }
+
+}

--- a/Source/Otc.SessionContext.AspNetCore.Jwt/AuthorizationDataSerializer.cs
+++ b/Source/Otc.SessionContext.AspNetCore.Jwt/AuthorizationDataSerializer.cs
@@ -1,37 +1,37 @@
 ﻿using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
-using Otc.SessionContext.Abstractions;
+using Otc.AuthorizationContext.Abstractions;
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 
-namespace Otc.SessionContext.AspNetCore.Jwt
+namespace Otc.AuthorizationContext.AspNetCore.Jwt
 {
-    [Obsolete("Otc.SessionContext.AspNetCore.Jwt.SessionSerializer now is Otc.AuthorizationContext.AspNetCore.Jwt.AuthorizationDataSerializer. We strongly encourage you to migrate from Otc.SessionContext.AspNetCore.Jwt to Otc.AuthorizationContext.AspNetCore.Jwt.")]
-    public class SessionSerializer<TSessionData> : ISessionSerializer<TSessionData>
-        where TSessionData : ISessionData
+    public class AuthorizationDataSerializer<TAuthorizationData> : IAuthorizationDataSerializer<TAuthorizationData>
+        where TAuthorizationData : IAuthorizationData
     {
         private readonly JwtConfiguration jwtConfiguration;
         private readonly JwtSecurityTokenHandler tokenHandler;
 
-        public SessionSerializer(JwtConfiguration jwtConfiguration)
+        public AuthorizationDataSerializer(JwtConfiguration jwtConfiguration)
+
         {
             this.jwtConfiguration = jwtConfiguration ?? throw new ArgumentNullException(nameof(jwtConfiguration));
             tokenHandler = new JwtSecurityTokenHandler();
         }
 
-        public string Serialize(TSessionData sessionData)
+        public string Serialize(TAuthorizationData authorizationData)
         {
-            return tokenHandler.WriteToken(GenerateJwtSecurityToken(sessionData));
+            return tokenHandler.WriteToken(GenerateJwtSecurityToken(authorizationData));
         }
 
-        private JwtSecurityToken GenerateJwtSecurityToken(TSessionData sessionData)
+        private JwtSecurityToken GenerateJwtSecurityToken(TAuthorizationData authorizationData)
         {
             var claims = new Claim[]
             {
-                new Claim(JwtRegisteredClaimNames.UniqueName, sessionData.UserId),
-                new Claim(JwtConfiguration.SessionDataJwtTypeName, JsonConvert.SerializeObject(sessionData))
+                new Claim(JwtRegisteredClaimNames.UniqueName, authorizationData.UserId),
+                new Claim(JwtConfiguration.AuthorizationDataJwtTypeName, JsonConvert.SerializeObject(authorizationData))
             };
 
             return new JwtSecurityToken(

--- a/Source/Otc.SessionContext.AspNetCore.Jwt/JwtConfiguration.cs
+++ b/Source/Otc.SessionContext.AspNetCore.Jwt/JwtConfiguration.cs
@@ -1,7 +1,9 @@
 ﻿using Otc.ComponentModel.DataAnnotations;
+using System;
 
 namespace Otc.SessionContext.AspNetCore.Jwt
 {
+    [Obsolete("Otc.SessionContext.AspNetCore.Jwt.JwtConfiguration now is Otc.AuthorizationContext.AspNetCore.Jwt.JwtConfiguration. We strongly encourage you to migrate from Otc.SessionContext.AspNetCore.Jwt to Otc.AuthorizationContext.AspNetCore.Jwt.")]
     public class JwtConfiguration
     {
         [Required]
@@ -14,5 +16,22 @@ namespace Otc.SessionContext.AspNetCore.Jwt
         public int ExpiresMinutes { get; set; } = 60;
 
         internal const string SessionDataJwtTypeName = "otc-session-data";
+    }
+}
+
+namespace Otc.AuthorizationContext.AspNetCore.Jwt
+{
+    public class JwtConfiguration
+    {
+        [Required]
+        public string Issuer { get; set; }
+        [Required]
+        public string SecretKey { get; set; }
+        [Required]
+        public string Audience { get; set; }
+
+        public int ExpiresMinutes { get; set; } = 60;
+
+        internal const string AuthorizationDataJwtTypeName = "otc-authorization-data";
     }
 }

--- a/Source/Otc.SessionContext.AspNetCore.Jwt/Microsoft.Extensions.DependencyInjection/OtcSessionContextServiceCollectionExtensions.cs
+++ b/Source/Otc.SessionContext.AspNetCore.Jwt/Microsoft.Extensions.DependencyInjection/OtcSessionContextServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using Otc.AuthorizationContext.Abstractions;
+using Otc.AuthorizationContext.AspNetCore.Jwt;
 using Otc.SessionContext.Abstractions;
 using Otc.SessionContext.AspNetCore.Jwt;
 using System;
@@ -9,7 +11,8 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class OtcSessionContextServiceCollectionExtensions
     {
-        public static IServiceCollection AddOtcAspNetCoreJwtSessionContext(this IServiceCollection services, JwtConfiguration jwtConfiguration)
+        [Obsolete("Use AddOtcAspNetCoreJwtAuthorizationContext instead; Otc.SessionContext.AspNetCore.Jwt now is Otc.AuthorizationContext.AspNetCore.Jwt. We strongly encourage you to migrate from Otc.SessionContext.AspNetCore.Jwt to Otc.AuthorizationContext.AspNetCore.Jwt.")]
+        public static IServiceCollection AddOtcAspNetCoreJwtSessionContext(this IServiceCollection services, Otc.SessionContext.AspNetCore.Jwt.JwtConfiguration jwtConfiguration)
         {
             if (services == null)
             {
@@ -24,6 +27,42 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(jwtConfiguration);
             services.AddSingleton(typeof(ISessionSerializer<>), typeof(SessionSerializer<>));
             services.AddScoped(typeof(ISessionContext<>), typeof(SessionContext<>));
+
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(options =>
+                {
+                    var apiConfiguration = jwtConfiguration;
+
+                    options.SaveToken = true;
+                    options.RequireHttpsMetadata = false;
+
+                    options.TokenValidationParameters = new TokenValidationParameters()
+                    {
+                        ValidIssuer = apiConfiguration.Issuer,
+                        ValidAudience = apiConfiguration.Audience,
+                        IssuerSigningKey = new SymmetricSecurityKey(
+                            Encoding.UTF8.GetBytes(apiConfiguration.SecretKey))
+                    };
+                });
+
+            return services;
+        }
+
+        public static IServiceCollection AddOtcAspNetCoreJwtAuthorizationContext(this IServiceCollection services, Otc.AuthorizationContext.AspNetCore.Jwt.JwtConfiguration jwtConfiguration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (jwtConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(jwtConfiguration));
+            }
+
+            services.AddSingleton(jwtConfiguration);
+            services.AddSingleton(typeof(IAuthorizationDataSerializer<>), typeof(AuthorizationDataSerializer<>));
+            services.AddScoped(typeof(IAuthorizationContext<>), typeof(AuthorizationContext<>));
 
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(options =>

--- a/Source/Otc.SessionContext.AspNetCore.Jwt/Otc.SessionContext.AspNetCore.Jwt.csproj
+++ b/Source/Otc.SessionContext.AspNetCore.Jwt/Otc.SessionContext.AspNetCore.Jwt.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Ole Consignado</Authors>
     <Copyright>Ole Consignado (c) 2018</Copyright>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-session-context</PackageProjectUrl>
   </PropertyGroup>
 

--- a/Source/Otc.SessionContext.AspNetCore.Jwt/SessionContext.cs
+++ b/Source/Otc.SessionContext.AspNetCore.Jwt/SessionContext.cs
@@ -7,6 +7,7 @@ using System.Security.Claims;
 
 namespace Otc.SessionContext.AspNetCore.Jwt
 {
+    [Obsolete("Otc.SessionContext.AspNetCore.Jwt.SessionContext now is Otc.AuthorizationContext.AspNetCore.Jwt.AuthorizationContext. We strongly encourage you to migrate from Otc.SessionContext.AspNetCore.Jwt to Otc.AuthorizationContext.AspNetCore.Jwt.")]
     public class SessionContext<TSessionData> : ISessionContext<TSessionData>
         where TSessionData : ISessionData
     {


### PR DESCRIPTION
Completely renamed *Session* to *Authorization* in order to improve semantics. All *Session* was kept and marked as obsolete.